### PR TITLE
pilight hub is filtering all events with "origin" parameter diferent …

### DIFF
--- a/homeassistant/components/pilight.py
+++ b/homeassistant/components/pilight.py
@@ -62,7 +62,7 @@ def setup(hass, config):
         hass, config[DOMAIN][CONF_SEND_DELAY])
 
     try:
-        pilight_client = pilight.Client(host=host, port=port)
+        pilight_client = pilight.Client(host=host, port=port, recv_codes_only=False)
     except (socket.error, socket.timeout) as err:
         _LOGGER.error(
             "Unable to connect to %s on port %s: %s", host, port, err)


### PR DESCRIPTION
…from "receiver"

Pilight uses "origin": "sender" for devices defined "inside" the platform running pilight (i.e. generic switches, gpios, cpu_temp, DS18b20 temp sensors , etc.)
In order to get all events from pilight, you have to instance pilight_client from python piligh lib with recv_codes_only=False
In pilight.py code of HA, you have to change:
pilight_client = pilight.Client(host=host, port=port, recv_codes_only=False)

By default recv_codes_only is True in pilight.py of python lib, so only RF codes are reported by pilight_client to HA.
To make gpio switch work I had to change “recv_codes_only=False” in instance of pilight_client, and now all events from pilight are been puted on HA bus!!!
The problem is that actually the pilight receive events, only work fine with RF external codes. It doesnt work with internal gpios,generic switches, etc.
Please, could be great that developers change this (or put an option to select).
I think that whitelist filter in HA is powerfull enought to set
recv_codes_only=False
as default, so all events in pilight are putting in HA bus.

Problem-relevant configuration.yaml entries and (fill out even if it seems unimportant):

Traceback (if applicable):
Additional information:

Could be great to fix the "echo" default behaviour of pilight-switch because it is setting True by default.

This make an infinite dead-lock switch-on/switch-off between pilight and Home Assistant, so you have to set:
echo: False

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) with documentation (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] New dependencies have been added to the `REQUIREMENTS` variable ([example][ex-requir]).
  - [ ] New dependencies are only imported inside functions that use them ([example][ex-import]).
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `script/gen_requirements_all.py`.
  - [ ] New files were added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[ex-requir]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L14
[ex-import]: https://github.com/home-assistant/home-assistant/blob/dev/homeassistant/components/keyboard.py#L54
